### PR TITLE
ensuring :pow is not being called on a primitive, used ^ instead

### DIFF
--- a/talisman.lua
+++ b/talisman.lua
@@ -181,7 +181,11 @@ function lenient_bignum(x)
   function math.exp(x)
     local big_e = to_big(2.718281828459045)
     
-    return lenient_bignum(big_e:pow(x))
+    if type(big_e) == "number" then
+      return lenient_bignum(big_e ^ x)
+    else
+      return lenient_bignum(big_e:pow(x))
+    end
   end 
 
   if SMODS then


### PR DESCRIPTION
Closes #56.

Game crashes on launch with mod active.
This fix ensures that this crash does not happen, by preventing the `:pow`-call on a primitive.

Feel free to comment on this, i naively fixed this and tested if my game was able to launch now.
Works after the fix.