### PR TITLE
Fix perma_X_chips not working

### DIFF
--- a/talisman.lua
+++ b/talisman.lua
@@ -742,8 +742,8 @@ end
 function Card:get_chip_x_bonus()
     if self.debuff then return 0 end
     if self.ability.set == 'Joker' then return 0 end
-    if (self.ability.x_chips or 0) <= 1 then return 0 end
-    return self.ability.x_chips
+    if (SMODS.multiplicative_stacking(self.ability.x_chips or 1, self.ability.perma_x_chips or 0) or 0) <= 1 then return 0 end
+    return SMODS.multiplicative_stacking(self.ability.x_chips or 1, self.ability.perma_x_chips or 0)
 end
 
 function Card:get_chip_e_bonus()


### PR DESCRIPTION
This part of the code was preventing perma_x_chips from working as it overrode SMOD's implementation, thus preventing it from being functional. This patch, while not elegant, ensures it becomes functional again.

https://github.com/user-attachments/assets/fec42d19-17e9-4866-a3e4-fe2c47edc6d5

