### PR TITLE
Optimize OmegaNum's `Big:arrow()` implementation

### DIFF
--- a/big-num/omeganum.lua
+++ b/big-num/omeganum.lua
@@ -1102,7 +1102,7 @@ function Big:max_for_op(arrows)
     if type(arrows) == "table" then
         arrows = arrows:to_number()
     end
-    if arrows < 1 then
+    if arrows < 1 or arrows ~= arrows or arrows == R.POSITIVE_INFINITY then
         return B.NaN:clone()
     end
     if arrows == 1 then


### PR DESCRIPTION
A grand majority of the time spent calculating `Big:arrow()` is a result of it assembling several large Big numbers on the fly. These numbers take the form of `10{number of arrows}(MAX_SAFE_INTEGER)`, which always outputs a number with a consistent and predictable pattern. This PR only calculates these numbers once, and does so with a bespoke algorithm that circumvents `Big:normalize()` and other arithmetic code entirely.

In my testing, this reduces the time for my `Big:arrow()` benchmark to complete from 6.00 seconds flat to about **0.15 seconds**, equivalent to a **40x speed-up**. Practical performance gains in-game are somewhere around 1.3x.

For one reason or another, this also seems to make the output of the benchmark match up with other OmegaNum implementations where it previously did not. Why this is the case, I'm not sure, but I'm not going to look this gift horse in the mouth.