### PR TITLE
Fix SMODS XChips message crash

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -1413,7 +1413,7 @@ match_indent = true
 target = "functions/common_events.lua"
 pattern = "text = localize{type='variable',key='a_xchips'..(amt<0 and '_minus' or ''),vars={math.abs(amt)}}"
 position = 'at'
-payload = "text = localize{type='variable',key='a_xchips'..(amt<to_big(0) and '_minus' or ''),vars={math.abs(amt)}}"
+payload = "text = localize{type='variable',key='a_xchips'..(to_big(amt)<to_big(0) and '_minus' or ''),vars={math.abs(amt)}}"
 times = 1
 match_indent = true
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -885,6 +885,16 @@ end
 '''
 match_indent = true
 
+## Ensure SMODS XChips messages won't crash in card_eval_status_text
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "text = localize{type='variable',key='a_xchips'..(amt<0 and '_minus' or ''),vars={math.abs(amt)}}"
+position = 'at'
+payload = "text = localize{type='variable',key='a_xchips'..(amt<to_big(0) and '_minus' or ''),vars={math.abs(amt)}}"
+times = 1
+match_indent = true
+
 [[patches]]
 [patches.pattern]
 target = "functions/common_events.lua"

--- a/lovely.toml
+++ b/lovely.toml
@@ -885,16 +885,6 @@ end
 '''
 match_indent = true
 
-## Ensure SMODS XChips messages won't crash in card_eval_status_text
-[[patches]]
-[patches.pattern]
-target = "functions/common_events.lua"
-pattern = "text = localize{type='variable',key='a_xchips'..(amt<0 and '_minus' or ''),vars={math.abs(amt)}}"
-position = 'at'
-payload = "text = localize{type='variable',key='a_xchips'..(amt<to_big(0) and '_minus' or ''),vars={math.abs(amt)}}"
-times = 1
-match_indent = true
-
 [[patches]]
 [patches.pattern]
 target = "functions/common_events.lua"
@@ -1416,6 +1406,15 @@ target = 'functions/common_events.lua'
 pattern = "text = localize{type='variable',key='a_xmult'..(amt<0 and '_minus' or ''),vars={math.abs(amt)}}"
 position = 'at'
 payload = "text = localize{type='variable',key='a_xmult'..(to_big(amt)<to_big(0) and '_minus' or ''),vars={math.abs(amt)}}"
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "text = localize{type='variable',key='a_xchips'..(amt<0 and '_minus' or ''),vars={math.abs(amt)}}"
+position = 'at'
+payload = "text = localize{type='variable',key='a_xchips'..(amt<to_big(0) and '_minus' or ''),vars={math.abs(amt)}}"
+times = 1
 match_indent = true
 
 [[patches]]


### PR DESCRIPTION
Fixed a crash that occurred when using any SMODS XChips return that attempts to automatically produce a message.