### PR TITLE
fix ease_dollars incorrectly changing career dollars earned stat

### DIFF
--- a/talisman.lua
+++ b/talisman.lua
@@ -850,7 +850,7 @@ local edo = ease_dollars
 function ease_dollars(mod, instant)
   if Talisman.config_file.disable_anims then--and (Talisman.calculating_joker or Talisman.calculating_score or Talisman.calculating_card) then
     mod = mod or 0
-    if to_big(mod) < to_big(0) then inc_career_stat('c_dollars_earned', mod) end
+    if to_big(mod) > to_big(0) then inc_career_stat('c_dollars_earned', mod) end
     G.GAME.dollars = G.GAME.dollars + mod
     Talisman.dollar_update = true
   else return edo(mod, instant) end


### PR DESCRIPTION
fixed ease_dollars only changing the dollars earned stat when *losing* money when animations are disabled