### PR TITLE
stop 2{n}2 from lagging/hard crashing with large values of n

### DIFF
--- a/big-num/omeganum.lua
+++ b/big-num/omeganum.lua
@@ -1210,6 +1210,12 @@ function Big:arrow(arrows, other)
     if (other:eq(B.ONE)) then
         return t:clone()
     end
+    if self:eq(2) and other:eq(2) then
+        -- handle infinite arrows
+        if arrows:isInfinite() then return Big:create(R.POSITIVE_INFINITY) end
+
+        return Big:create(4)
+    end
     --[[if (arrows:gte(maxArrow)) then
         return Big:create(B.POSITIVE_INFINITY)
     end--]]


### PR DESCRIPTION
pretty rare but my mod adds a joker that gives +2{n}2 mult as a joke addition, and i don't want that to cause extreme amounts of lag if someone decides to smoothie it like 5000 times